### PR TITLE
Migrate plugins to use ErrorMessage class

### DIFF
--- a/misc/proper_plugin.py
+++ b/misc/proper_plugin.py
@@ -1,3 +1,4 @@
+from mypy import message_registry
 from mypy.plugin import Plugin, FunctionContext
 from mypy.types import (
     Type, Instance, CallableType, UnionType, get_proper_type, ProperType,
@@ -43,8 +44,7 @@ def isinstance_proper_hook(ctx: FunctionContext) -> Type:
                 isinstance(get_proper_type(arg), AnyType) and is_dangerous_target(right)):
             if is_special_target(right):
                 return ctx.default_return_type
-            ctx.api.fail('Never apply isinstance() to unexpanded types;'
-                         ' use mypy.types.get_proper_type() first', ctx.context)
+            ctx.api.fail(message_registry.ISINSTANCE_ON_UNEXPANDED_TYPE, ctx.context)
             ctx.api.note('If you pass on the original type'  # type: ignore[attr-defined]
                          ' after the check, always use its unexpanded version', ctx.context)
     return ctx.default_return_type
@@ -113,7 +113,7 @@ def proper_type_hook(ctx: FunctionContext) -> Type:
             # Minimize amount of spurious errors from overload machinery.
             # TODO: call the hook on the overload as a whole?
             if isinstance(arg_type, (UnionType, Instance)):
-                ctx.api.fail('Redundant call to get_proper_type()', ctx.context)
+                ctx.api.fail(message_registry.REDUNDANT_GET_PROPER_TYPE, ctx.context)
     return ctx.default_return_type
 
 
@@ -126,7 +126,7 @@ def proper_types_hook(ctx: FunctionContext) -> Type:
         item_type = UnionType.make_union([NoneTyp(), proper_type])
         ok_type = ctx.api.named_generic_type('typing.Iterable', [item_type])
         if is_proper_subtype(arg_type, ok_type):
-            ctx.api.fail('Redundant call to get_proper_types()', ctx.context)
+            ctx.api.fail(message_registry.REDUNDANT_GET_PROPER_TYPE, ctx.context)
     return ctx.default_return_type
 
 

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -711,3 +711,73 @@ CLASS_PATTERN_KEYWORD_MATCHES_POSITIONAL: Final = (
 CLASS_PATTERN_DUPLICATE_KEYWORD_PATTERN: Final = 'Duplicate keyword pattern "{}"'
 CLASS_PATTERN_UNKNOWN_KEYWORD: Final = 'Class "{}" has no attribute "{}"'
 MULTIPLE_ASSIGNMENTS_IN_PATTERN: Final = 'Multiple assignments to name "{}" in pattern'
+
+# Plugin: attrs
+CANNOT_DETERMINE_INIT_TYPE: Final = ErrorMessage("Cannot determine __init__ type from converter")
+CMP_WITH_EQ_AND_ORDER: Final = ErrorMessage('Don\'t mix "cmp" with "eq" and "order"')
+EQ_TRUE_IF_ORDER_TRUE: Final = ErrorMessage("eq must be True if order is True")
+ARG_MUST_BE_TRUE_OR_FALSE: Final = ErrorMessage('"{}" argument must be True or False.')
+AUTO_ATTRIBS_UNSUPPORTED_PY2: Final = ErrorMessage("auto_attribs is not supported in Python 2")
+ATTRS_NEWSTYLE_CLASS_ONLY: Final = ErrorMessage("attrs only works with new-style classes")
+KW_ONLY_UNSUPPORTED_PY2: Final = ErrorMessage("kw_only is not supported in Python 2")
+DEFAULT_WITH_FACTORY: Final = ErrorMessage('Can\'t pass both "default" and "factory".')
+TYPE_INVALID_ARG: Final = ErrorMessage("Invalid argument to type")
+NON_DEFAULT_ATTRS_AFTER_DEFAULT: Final = ErrorMessage(
+    "Non-default attributes not allowed after default attributes."
+)
+ATTR_TOO_MANY_NAMES: Final = ErrorMessage("Too many names for one attribute")
+CONVERT_WITH_CONVERTER: Final = ErrorMessage('Can\'t pass both "convert" and "converter".')
+CONVERT_DEPRECATED: Final = ErrorMessage("convert is deprecated, use converter")
+UNSUPPORTED_CONVERTER: Final = ErrorMessage(
+    "Unsupported converter, only named functions and types are currently supported"
+)
+
+# Plugin: functools
+TOTAL_ORDERING_NO_OPERATOR_DEFINED: Final = ErrorMessage(
+    'No ordering operation defined when using "functools.total_ordering": < > <= >='
+)
+
+# Plugin: dataclasses
+DATACLASS_ORDER_METHODS_DISALLOWED: Final = ErrorMessage(
+    "You may not have a custom {} method when order=True"
+)
+DATACLASS_DEFAULT_ATTRS_BEFORE_NON_DEFAULT: Final = ErrorMessage(
+    "Attributes without a default cannot follow attributes with one"
+)
+DATACLASS_SINGLE_KW_ONLY_TYPE: Final = ErrorMessage(
+    "There may not be more than one field with the KW_ONLY type"
+)
+DATACLASS_UNPACKING_KWARGS_IN_FIELD: Final = ErrorMessage(
+    'Unpacking **kwargs in "field()" is not supported'
+)
+DATACLASS_POS_ARG_IN_FIELD: Final = ErrorMessage('"field()" does not accept positional arguments')
+DATACLASS_SLOTS_ABOVE_PY310: Final = ErrorMessage(
+    'Keyword argument "slots" for "dataclass" is only valid in Python 3.10 and higher'
+)
+DATACLASS_SLOTS_CLASH: Final = ErrorMessage(
+    '"{}" both defines "__slots__" and is used with "slots=True"'
+)
+
+# Plugin: ctypes
+CTYPES_VALUE_WITH_CHAR_OR_WCHAR_ONLY: Final = ErrorMessage(
+    'Array attribute "value" is only available with element type "c_char" or "c_wchar", not {}'
+)
+CTYPES_RAW_WITH_CHAR_ONLY: Final = ErrorMessage(
+    'Array attribute "raw" is only available with element type "c_char", not {}'
+)
+CTYPES_INCOMPATIBLE_CONSTRUCTOR_ARG: Final = ErrorMessage(
+    "Array constructor argument {} of type {} is not convertible to the array element type {}"
+)
+
+# Plugin: singledispatch
+SINGLEDISPATCH_ATLEAST_ONE_ARG: Final = ErrorMessage(
+    "Singledispatch function requires at least one argument"
+)
+SINGLEDISPATCH_FIRST_ARG_POSITIONAL: Final = ErrorMessage(
+    "First argument to singledispatch function must be a positional argument"
+)
+DISPATCH_TYPE_FALLBACK_SUBTYPE: Final = ErrorMessage(
+    "Dispatch type {} must be subtype of fallback function first argument {}"
+)
+
+INVALID_SIGNAL_TYPE: Final = ErrorMessage('Invalid "Signal" type (expected "Signal[[t, ...]]")')

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -780,4 +780,12 @@ DISPATCH_TYPE_FALLBACK_SUBTYPE: Final = ErrorMessage(
     "Dispatch type {} must be subtype of fallback function first argument {}"
 )
 
+# misc/proper_plugin.py
+ISINSTANCE_ON_UNEXPANDED_TYPE: Final = ErrorMessage(
+    "Never apply isinstance() to unexpanded types; use mypy.types.get_proper_type() first"
+)
+REDUNDANT_GET_PROPER_TYPE: Final = ErrorMessage("Redundant call to get_proper_type()")
+
+
+# test-data/type_anal_hook.py
 INVALID_SIGNAL_TYPE: Final = ErrorMessage('Invalid "Signal" type (expected "Signal[[t, ...]]")')

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -223,10 +223,8 @@ class CheckerPluginInterface:
         """Return the type context of the plugin"""
         raise NotImplementedError
 
-    # TODO(tushar): remove `str` type and `code` property from here
     @abstractmethod
-    def fail(self, msg: Union[str, ErrorMessage], ctx: Context, *,
-             code: Optional[ErrorCode] = None) -> None:
+    def fail(self, msg: ErrorMessage, ctx: Context) -> None:
         """Emit an error message at given location."""
         raise NotImplementedError
 
@@ -285,8 +283,8 @@ class SemanticAnalyzerPluginInterface:
         raise NotImplementedError
 
     @abstractmethod
-    def fail(self, msg: Union[str, ErrorMessage], ctx: Context, serious: bool = False, *,
-             blocker: bool = False, code: Optional[ErrorCode] = None) -> None:
+    def fail(self, msg: ErrorMessage, ctx: Context, serious: bool = False, *,
+             blocker: bool = False) -> None:
         """Emit an error message at given location."""
         raise NotImplementedError
 

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -120,7 +120,7 @@ semantic analyzer is enabled (it's always true in mypy 0.730 and later).
 """
 
 from abc import abstractmethod
-from typing import Any, Callable, List, Tuple, Optional, NamedTuple, TypeVar, Dict, Union
+from typing import Any, Callable, List, Tuple, Optional, NamedTuple, TypeVar, Dict
 from mypy_extensions import trait, mypyc_attr
 
 from mypy.nodes import (
@@ -133,7 +133,6 @@ from mypy.types import (
 from mypy.messages import MessageBuilder
 from mypy.options import Options
 from mypy.lookup import lookup_fully_qualified
-from mypy.errorcodes import ErrorCode
 from mypy.message_registry import ErrorMessage
 
 

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -1,5 +1,6 @@
 """Plugin for supporting the attrs library (http://www.attrs.org)"""
 
+from mypy import message_registry
 from mypy.backports import OrderedDict
 
 from typing import Optional, Dict, List, cast, Tuple, Iterable
@@ -130,7 +131,7 @@ class Attribute:
                 init_type = UnionType.make_union([init_type, NoneType()])
 
             if not init_type:
-                ctx.api.fail("Cannot determine __init__ type from converter", self.context)
+                ctx.api.fail(message_registry.CANNOT_DETERMINE_INIT_TYPE, self.context)
                 init_type = AnyType(TypeOfAny.from_error)
         elif self.converter.name == '':
             # This means we had a converter but it's not of a type we can infer.
@@ -210,7 +211,7 @@ def _determine_eq_order(ctx: 'mypy.plugin.ClassDefContext') -> bool:
     order = _get_decorator_optional_bool_argument(ctx, 'order')
 
     if cmp is not None and any((eq is not None, order is not None)):
-        ctx.api.fail('Don\'t mix "cmp" with "eq" and "order"', ctx.reason)
+        ctx.api.fail(message_registry.CMP_WITH_EQ_AND_ORDER, ctx.reason)
 
     # cmp takes precedence due to bw-compatibility.
     if cmp is not None:
@@ -224,7 +225,7 @@ def _determine_eq_order(ctx: 'mypy.plugin.ClassDefContext') -> bool:
         order = eq
 
     if eq is False and order is True:
-        ctx.api.fail('eq must be True if order is True', ctx.reason)
+        ctx.api.fail(message_registry.EQ_TRUE_IF_ORDER_TRUE, ctx.reason)
 
     return order
 
@@ -248,7 +249,7 @@ def _get_decorator_optional_bool_argument(
                     return False
                 if attr_value.fullname == 'builtins.None':
                     return None
-            ctx.api.fail('"{}" argument must be True or False.'.format(name), ctx.reason)
+            ctx.api.fail(message_registry.ARG_MUST_BE_TRUE_OR_FALSE.format(name), ctx.reason)
             return default
         return default
     else:
@@ -281,14 +282,14 @@ def attr_class_maker_callback(ctx: 'mypy.plugin.ClassDefContext',
 
     if ctx.api.options.python_version[0] < 3:
         if auto_attribs:
-            ctx.api.fail("auto_attribs is not supported in Python 2", ctx.reason)
+            ctx.api.fail(message_registry.AUTO_ATTRIBS_UNSUPPORTED_PY2, ctx.reason)
             return
         if not info.defn.base_type_exprs:
             # Note: This will not catch subclassing old-style classes.
-            ctx.api.fail("attrs only works with new-style classes", info.defn)
+            ctx.api.fail(message_registry.ATTRS_NEWSTYLE_CLASS_ONLY, info.defn)
             return
         if kw_only:
-            ctx.api.fail(KW_ONLY_PYTHON_2_UNSUPPORTED, ctx.reason)
+            ctx.api.fail(message_registry.KW_ONLY_UNSUPPORTED_PY2, ctx.reason)
             return
 
     attributes = _analyze_class(ctx, auto_attribs, kw_only)
@@ -407,9 +408,7 @@ def _analyze_class(ctx: 'mypy.plugin.ClassDefContext',
         context = attribute.context if i >= len(super_attrs) else ctx.cls
 
         if not attribute.has_default and last_default:
-            ctx.api.fail(
-                "Non-default attributes not allowed after default attributes.",
-                context)
+            ctx.api.fail(message_registry.NON_DEFAULT_ATTRS_AFTER_DEFAULT, context)
         last_default |= attribute.has_default
 
     return attributes
@@ -532,7 +531,7 @@ def _attribute_from_attrib_maker(ctx: 'mypy.plugin.ClassDefContext',
         return None
 
     if len(stmt.lvalues) > 1:
-        ctx.api.fail("Too many names for one attribute", stmt)
+        ctx.api.fail(message_registry.ATTR_TOO_MANY_NAMES, stmt)
         return None
 
     # This is the type that belongs in the __init__ method for this attrib.
@@ -544,7 +543,7 @@ def _attribute_from_attrib_maker(ctx: 'mypy.plugin.ClassDefContext',
     # See https://github.com/python-attrs/attrs/issues/481 for explanation.
     kw_only |= _get_bool_argument(ctx, rvalue, 'kw_only', False)
     if kw_only and ctx.api.options.python_version[0] < 3:
-        ctx.api.fail(KW_ONLY_PYTHON_2_UNSUPPORTED, stmt)
+        ctx.api.fail(message_registry.KW_ONLY_UNSUPPORTED_PY2, stmt)
         return None
 
     # TODO: Check for attr.NOTHING
@@ -552,7 +551,7 @@ def _attribute_from_attrib_maker(ctx: 'mypy.plugin.ClassDefContext',
     attr_has_factory = bool(_get_argument(rvalue, 'factory'))
 
     if attr_has_default and attr_has_factory:
-        ctx.api.fail('Can\'t pass both "default" and "factory".', rvalue)
+        ctx.api.fail(message_registry.DEFAULT_WITH_FACTORY, rvalue)
     elif attr_has_factory:
         attr_has_default = True
 
@@ -562,7 +561,7 @@ def _attribute_from_attrib_maker(ctx: 'mypy.plugin.ClassDefContext',
         try:
             un_type = expr_to_unanalyzed_type(type_arg, ctx.api.options, ctx.api.is_stub_file)
         except TypeTranslationError:
-            ctx.api.fail('Invalid argument to type', type_arg)
+            ctx.api.fail(message_registry.TYPE_INVALID_ARG, type_arg)
         else:
             init_type = ctx.api.anal_type(un_type)
             if init_type and isinstance(lhs.node, Var) and not lhs.node.type:
@@ -574,9 +573,9 @@ def _attribute_from_attrib_maker(ctx: 'mypy.plugin.ClassDefContext',
     converter = _get_argument(rvalue, 'converter')
     convert = _get_argument(rvalue, 'convert')
     if convert and converter:
-        ctx.api.fail('Can\'t pass both "convert" and "converter".', rvalue)
+        ctx.api.fail(message_registry.CONVERT_WITH_CONVERTER, rvalue)
     elif convert:
-        ctx.api.fail("convert is deprecated, use converter", rvalue)
+        ctx.api.fail(message_registry.CONVERT_DEPRECATED, rvalue)
         converter = convert
     converter_info = _parse_converter(ctx, converter)
 
@@ -613,10 +612,7 @@ def _parse_converter(ctx: 'mypy.plugin.ClassDefContext',
             return argument
 
         # Signal that we have an unsupported converter.
-        ctx.api.fail(
-            "Unsupported converter, only named functions and types are currently supported",
-            converter
-        )
+        ctx.api.fail(message_registry.UNSUPPORTED_CONVERTER, converter)
         return Converter('')
     return Converter(None)
 

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -1,5 +1,6 @@
 from typing import List, Optional, Union
 
+from mypy import message_registry
 from mypy.nodes import (
     ARG_POS, MDEF, Argument, Block, CallExpr, ClassDef, Expression, SYMBOL_FUNCBASE_TYPES,
     FuncDef, PassStmt, RefExpr, SymbolTableNode, Var, JsonDict,
@@ -39,7 +40,7 @@ def _get_bool_argument(ctx: ClassDefContext, expr: CallExpr,
     if attr_value:
         ret = ctx.api.parse_bool(attr_value)
         if ret is None:
-            ctx.api.fail('"{}" argument must be True or False.'.format(name), expr)
+            ctx.api.fail(message_registry.ARG_MUST_BE_TRUE_OR_FALSE.format(name), expr)
             return default
         return ret
     return default

--- a/mypy/plugins/ctypes.py
+++ b/mypy/plugins/ctypes.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 # Fully qualified instead of "from mypy.plugin import ..." to avoid circular import problems.
 import mypy.plugin
-from mypy import nodes
+from mypy import message_registry, nodes
 from mypy.maptype import map_instance_to_supertype
 from mypy.messages import format_type
 from mypy.subtypes import is_subtype
@@ -125,17 +125,15 @@ def array_constructor_callback(ctx: 'mypy.plugin.FunctionContext') -> Type:
             "The stub of the ctypes.Array constructor should have a single vararg parameter"
         for arg_num, (arg_kind, arg_type) in enumerate(zip(ctx.arg_kinds[0], ctx.arg_types[0]), 1):
             if arg_kind == nodes.ARG_POS and not is_subtype(arg_type, allowed):
-                ctx.api.msg.fail(
-                    'Array constructor argument {} of type {}'
-                    ' is not convertible to the array element type {}'
+                ctx.api.fail(
+                    message_registry.CTYPES_INCOMPATIBLE_CONSTRUCTOR_ARG
                     .format(arg_num, format_type(arg_type), format_type(et)), ctx.context)
             elif arg_kind == nodes.ARG_STAR:
                 ty = ctx.api.named_generic_type("typing.Iterable", [allowed])
                 if not is_subtype(arg_type, ty):
                     it = ctx.api.named_generic_type("typing.Iterable", [et])
-                    ctx.api.msg.fail(
-                        'Array constructor argument {} of type {}'
-                        ' is not convertible to the array element type {}'
+                    ctx.api.fail(
+                        message_registry.CTYPES_INCOMPATIBLE_CONSTRUCTOR_ARG
                         .format(arg_num, format_type(arg_type), format_type(it)), ctx.context)
 
     return ctx.default_return_type
@@ -203,9 +201,8 @@ def array_value_callback(ctx: 'mypy.plugin.AttributeContext') -> Type:
             elif isinstance(tp, Instance) and tp.type.fullname == 'ctypes.c_wchar':
                 types.append(_get_text_type(ctx.api))
             else:
-                ctx.api.msg.fail(
-                    'Array attribute "value" is only available'
-                    ' with element type "c_char" or "c_wchar", not {}'
+                ctx.api.fail(
+                    message_registry.CTYPES_VALUE_WITH_CHAR_OR_WCHAR_ONLY
                     .format(format_type(et)), ctx.context)
         return make_simplified_union(types)
     return ctx.default_attr_type
@@ -221,9 +218,8 @@ def array_raw_callback(ctx: 'mypy.plugin.AttributeContext') -> Type:
                     or isinstance(tp, Instance) and tp.type.fullname == 'ctypes.c_char'):
                 types.append(_get_bytes_type(ctx.api))
             else:
-                ctx.api.msg.fail(
-                    'Array attribute "raw" is only available'
-                    ' with element type "c_char", not {}'
+                ctx.api.fail(
+                    message_registry.CTYPES_RAW_WITH_CHAR_ONLY
                     .format(format_type(et)), ctx.context)
         return make_simplified_union(types)
     return ctx.default_attr_type

--- a/mypy/plugins/functools.py
+++ b/mypy/plugins/functools.py
@@ -3,6 +3,7 @@ from typing import Dict, NamedTuple, Optional
 from typing_extensions import Final
 
 import mypy.plugin
+from mypy import message_registry
 from mypy.nodes import ARG_POS, ARG_STAR2, Argument, FuncItem, Var
 from mypy.plugins.common import add_method_to_class
 from mypy.types import AnyType, CallableType, get_proper_type, Type, TypeOfAny, UnboundType
@@ -32,9 +33,7 @@ def functools_total_ordering_maker_callback(ctx: mypy.plugin.ClassDefContext,
 
     comparison_methods = _analyze_class(ctx)
     if not comparison_methods:
-        ctx.api.fail(
-            'No ordering operation defined when using "functools.total_ordering": < > <= >=',
-            ctx.reason)
+        ctx.api.fail(message_registry.TOTAL_ORDERING_NO_OPERATOR_DEFINED, ctx.reason)
         return
 
     # prefer __lt__ to __le__ to __gt__ to __ge__

--- a/test-data/unit/plugins/type_anal_hook.py
+++ b/test-data/unit/plugins/type_anal_hook.py
@@ -5,6 +5,7 @@ from mypy.types import Type, TypeList, AnyType, CallableType, TypeOfAny
 # The official name changed to NoneType but we have an alias for plugin compat reasons
 # so we'll keep testing that here.
 from mypy.types import NoneTyp
+from mypy import message_registry
 
 class TypeAnalyzePlugin(Plugin):
     def get_type_analyze_hook(self, fullname: str
@@ -17,7 +18,7 @@ class TypeAnalyzePlugin(Plugin):
 def signal_type_analyze_callback(ctx: AnalyzeTypeContext) -> Type:
     if (len(ctx.type.args) != 1
             or not isinstance(ctx.type.args[0], TypeList)):
-        ctx.api.fail('Invalid "Signal" type (expected "Signal[[t, ...]]")', ctx.context)
+        ctx.api.fail(message_registry.INVALID_SIGNAL_TYPE, ctx.context)
         return AnyType(TypeOfAny.from_error)
 
     args = ctx.type.args[0]


### PR DESCRIPTION
Note that the change to `fail` in the interfaces in `plugin.py` will break all plugins.